### PR TITLE
Replace {{resourceId}} in validation rules

### DIFF
--- a/src/HasTranslatable.php
+++ b/src/HasTranslatable.php
@@ -44,6 +44,20 @@ trait HasTranslatable
             }
         }
 
-        return $rules;
+        $replacements = array_filter([
+            '{{resourceId}}' => str_replace(['\'', '"', ',', '\\'], '', $request->resourceId),
+        ]);
+
+        if (empty($replacements)) {
+            return $rules;
+        }
+
+        return collect($rules)->map(function ($rules) use ($replacements) {
+            return collect($rules)->map(function ($rule) use ($replacements) {
+                return is_string($rule)
+                    ? str_replace(array_keys($replacements), array_values($replacements), $rule)
+                    : $rule;
+            })->all();
+        })->all();
     }
 }


### PR DESCRIPTION
Nova offers the possibility to add a {{resourceId}} inside a validation rule, like:
'unique:users,email,{{resourceId}}'

This patch adds the ability to replace {{resourceId}} by the actual resource id.